### PR TITLE
Reworked hw5

### DIFF
--- a/T-Chat.xcodeproj/project.pbxproj
+++ b/T-Chat.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		003BC9EC252DAA99007F982E /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003BC9EB252DAA99007F982E /* Theme.swift */; };
 		003BC9EE252DCD98007F982E /* ThemesPickerDelegateProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003BC9ED252DCD98007F982E /* ThemesPickerDelegateProtocol.swift */; };
+		003BCA182534573B007F982E /* exampleView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 003BCA172534573B007F982E /* exampleView.storyboard */; };
+		003BCA1A2534589E007F982E /* exampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003BCA192534589E007F982E /* exampleView.swift */; };
 		004ED005251E482C0093C1E2 /* ConversationsListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 004ED004251E482C0093C1E2 /* ConversationsListViewController.swift */; };
 		004ED007251E486F0093C1E2 /* ConversationsListViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 004ED006251E486F0093C1E2 /* ConversationsListViewController.storyboard */; };
 		004ED009251E500D0093C1E2 /* ConversationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 004ED008251E500D0093C1E2 /* ConversationCell.swift */; };
@@ -32,6 +34,8 @@
 /* Begin PBXFileReference section */
 		003BC9EB252DAA99007F982E /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		003BC9ED252DCD98007F982E /* ThemesPickerDelegateProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesPickerDelegateProtocol.swift; sourceTree = "<group>"; };
+		003BCA172534573B007F982E /* exampleView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = exampleView.storyboard; sourceTree = "<group>"; };
+		003BCA192534589E007F982E /* exampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = exampleView.swift; sourceTree = "<group>"; };
 		004ED004251E482C0093C1E2 /* ConversationsListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationsListViewController.swift; sourceTree = "<group>"; };
 		004ED006251E486F0093C1E2 /* ConversationsListViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ConversationsListViewController.storyboard; sourceTree = "<group>"; };
 		004ED008251E500D0093C1E2 /* ConversationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationCell.swift; sourceTree = "<group>"; };
@@ -72,6 +76,7 @@
 				004ED020252B20A40093C1E2 /* ThemesViewController.storyboard */,
 				004ED006251E486F0093C1E2 /* ConversationsListViewController.storyboard */,
 				004ED01425233FF50093C1E2 /* ConversationViewController.storyboard */,
+				003BCA172534573B007F982E /* exampleView.storyboard */,
 				00AA12FC250EA6E500B8B4C8 /* LaunchScreen.storyboard */,
 			);
 			name = Storyboards;
@@ -84,6 +89,7 @@
 				004ED024252B6E4D0093C1E2 /* ThemesViewController.swift */,
 				004ED004251E482C0093C1E2 /* ConversationsListViewController.swift */,
 				004ED00E25233A8E0093C1E2 /* ConversationViewController.swift */,
+				003BCA192534589E007F982E /* exampleView.swift */,
 			);
 			name = ViewControllers;
 			sourceTree = "<group>";
@@ -209,6 +215,7 @@
 			files = (
 				004ED01525233FF50093C1E2 /* ConversationViewController.storyboard in Resources */,
 				004ED021252B20A40093C1E2 /* ThemesViewController.storyboard in Resources */,
+				003BCA182534573B007F982E /* exampleView.storyboard in Resources */,
 				00AA12FE250EA6E500B8B4C8 /* LaunchScreen.storyboard in Resources */,
 				00AA12FB250EA6E500B8B4C8 /* Assets.xcassets in Resources */,
 				00D5833F2514AFD300243033 /* ProfileViewController.storyboard in Resources */,
@@ -232,6 +239,7 @@
 				004ED00D251E71620093C1E2 /* HardcodedConversationsList.swift in Sources */,
 				004ED01125233B2A0093C1E2 /* HardcodedConversationData.swift in Sources */,
 				00D583412514AFFC00243033 /* ProfileViewController.swift in Sources */,
+				003BCA1A2534589E007F982E /* exampleView.swift in Sources */,
 				004ED01325233B6B0093C1E2 /* MessageCellModel.swift in Sources */,
 				00AA12F2250EA6E200B8B4C8 /* AppDelegate.swift in Sources */,
 				004ED009251E500D0093C1E2 /* ConversationCell.swift in Sources */,

--- a/T-Chat.xcodeproj/project.pbxproj
+++ b/T-Chat.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		003BCA182534573B007F982E /* exampleView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 003BCA172534573B007F982E /* exampleView.storyboard */; };
 		003BCA1A2534589E007F982E /* exampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003BCA192534589E007F982E /* exampleView.swift */; };
 		00451BE4253CDDE0003925B9 /* GCDManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00451BE3253CDDE0003925B9 /* GCDManager.swift */; };
+		00451BE7253ED8C6003925B9 /* OperationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00451BE6253ED8C6003925B9 /* OperationManager.swift */; };
+		00451BE9253F0F88003925B9 /* Multithreading managers structs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00451BE8253F0F88003925B9 /* Multithreading managers structs.swift */; };
 		004ED005251E482C0093C1E2 /* ConversationsListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 004ED004251E482C0093C1E2 /* ConversationsListViewController.swift */; };
 		004ED007251E486F0093C1E2 /* ConversationsListViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 004ED006251E486F0093C1E2 /* ConversationsListViewController.storyboard */; };
 		004ED009251E500D0093C1E2 /* ConversationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 004ED008251E500D0093C1E2 /* ConversationCell.swift */; };
@@ -38,6 +40,8 @@
 		003BCA172534573B007F982E /* exampleView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = exampleView.storyboard; sourceTree = "<group>"; };
 		003BCA192534589E007F982E /* exampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = exampleView.swift; sourceTree = "<group>"; };
 		00451BE3253CDDE0003925B9 /* GCDManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GCDManager.swift; sourceTree = "<group>"; };
+		00451BE6253ED8C6003925B9 /* OperationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationManager.swift; sourceTree = "<group>"; };
+		00451BE8253F0F88003925B9 /* Multithreading managers structs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Multithreading managers structs.swift"; sourceTree = "<group>"; };
 		004ED004251E482C0093C1E2 /* ConversationsListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationsListViewController.swift; sourceTree = "<group>"; };
 		004ED006251E486F0093C1E2 /* ConversationsListViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ConversationsListViewController.storyboard; sourceTree = "<group>"; };
 		004ED008251E500D0093C1E2 /* ConversationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationCell.swift; sourceTree = "<group>"; };
@@ -75,6 +79,7 @@
 			isa = PBXGroup;
 			children = (
 				00451BE3253CDDE0003925B9 /* GCDManager.swift */,
+				00451BE6253ED8C6003925B9 /* OperationManager.swift */,
 			);
 			name = Managers;
 			sourceTree = "<group>";
@@ -121,6 +126,7 @@
 				004ED01C2523C9DF0093C1E2 /* ConversationCellModel.swift */,
 				003BC9EB252DAA99007F982E /* Theme.swift */,
 				003BC9ED252DCD98007F982E /* ThemesPickerDelegateProtocol.swift */,
+				00451BE8253F0F88003925B9 /* Multithreading managers structs.swift */,
 			);
 			name = "Models & Protocols";
 			sourceTree = "<group>";
@@ -254,8 +260,10 @@
 				003BCA1A2534589E007F982E /* exampleView.swift in Sources */,
 				004ED01325233B6B0093C1E2 /* MessageCellModel.swift in Sources */,
 				00AA12F2250EA6E200B8B4C8 /* AppDelegate.swift in Sources */,
+				00451BE9253F0F88003925B9 /* Multithreading managers structs.swift in Sources */,
 				004ED009251E500D0093C1E2 /* ConversationCell.swift in Sources */,
 				004ED025252B6E4D0093C1E2 /* ThemesViewController.swift in Sources */,
+				00451BE7253ED8C6003925B9 /* OperationManager.swift in Sources */,
 				004ED01D2523C9DF0093C1E2 /* ConversationCellModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/T-Chat.xcodeproj/project.pbxproj
+++ b/T-Chat.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		003BC9EE252DCD98007F982E /* ThemesPickerDelegateProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003BC9ED252DCD98007F982E /* ThemesPickerDelegateProtocol.swift */; };
 		003BCA182534573B007F982E /* exampleView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 003BCA172534573B007F982E /* exampleView.storyboard */; };
 		003BCA1A2534589E007F982E /* exampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003BCA192534589E007F982E /* exampleView.swift */; };
+		00451BE4253CDDE0003925B9 /* GCDManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00451BE3253CDDE0003925B9 /* GCDManager.swift */; };
 		004ED005251E482C0093C1E2 /* ConversationsListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 004ED004251E482C0093C1E2 /* ConversationsListViewController.swift */; };
 		004ED007251E486F0093C1E2 /* ConversationsListViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 004ED006251E486F0093C1E2 /* ConversationsListViewController.storyboard */; };
 		004ED009251E500D0093C1E2 /* ConversationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 004ED008251E500D0093C1E2 /* ConversationCell.swift */; };
@@ -36,6 +37,7 @@
 		003BC9ED252DCD98007F982E /* ThemesPickerDelegateProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesPickerDelegateProtocol.swift; sourceTree = "<group>"; };
 		003BCA172534573B007F982E /* exampleView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = exampleView.storyboard; sourceTree = "<group>"; };
 		003BCA192534589E007F982E /* exampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = exampleView.swift; sourceTree = "<group>"; };
+		00451BE3253CDDE0003925B9 /* GCDManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GCDManager.swift; sourceTree = "<group>"; };
 		004ED004251E482C0093C1E2 /* ConversationsListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationsListViewController.swift; sourceTree = "<group>"; };
 		004ED006251E486F0093C1E2 /* ConversationsListViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ConversationsListViewController.storyboard; sourceTree = "<group>"; };
 		004ED008251E500D0093C1E2 /* ConversationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationCell.swift; sourceTree = "<group>"; };
@@ -69,6 +71,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		00451BE5253CDDED003925B9 /* Managers */ = {
+			isa = PBXGroup;
+			children = (
+				00451BE3253CDDE0003925B9 /* GCDManager.swift */,
+			);
+			name = Managers;
+			sourceTree = "<group>";
+		};
 		004ED0182523C9100093C1E2 /* Storyboards */ = {
 			isa = PBXGroup;
 			children = (
@@ -147,6 +157,7 @@
 				004ED01F2523CA4C0093C1E2 /* HardcodedData */,
 				004ED01E2523CA120093C1E2 /* Models & Protocols */,
 				004ED01B2523C97D0093C1E2 /* Views */,
+				00451BE5253CDDED003925B9 /* Managers */,
 				004ED01A2523C9570093C1E2 /* ViewControllers */,
 				004ED0182523C9100093C1E2 /* Storyboards */,
 				00AA12FA250EA6E500B8B4C8 /* Assets.xcassets */,
@@ -234,6 +245,7 @@
 				004ED005251E482C0093C1E2 /* ConversationsListViewController.swift in Sources */,
 				004ED00F25233A8E0093C1E2 /* ConversationViewController.swift in Sources */,
 				004ED00B251E5DEB0093C1E2 /* ConfigurableViewProtocol.swift in Sources */,
+				00451BE4253CDDE0003925B9 /* GCDManager.swift in Sources */,
 				003BC9EE252DCD98007F982E /* ThemesPickerDelegateProtocol.swift in Sources */,
 				003BC9EC252DAA99007F982E /* Theme.swift in Sources */,
 				004ED00D251E71620093C1E2 /* HardcodedConversationsList.swift in Sources */,

--- a/T-Chat/GCDManager.swift
+++ b/T-Chat/GCDManager.swift
@@ -1,0 +1,185 @@
+//
+//  GCDManager.swift
+//  T-Chat
+//
+//  Created by Дмитрий on 15.10.2020.
+//  Copyright © 2020 DP. All rights reserved.
+//
+
+import UIKit
+
+enum Result {
+    case sucess
+    case fail
+}
+
+struct StringData {
+    var str: String = ""
+    var result: Result = .sucess
+    var errorDescription: String = ""
+}
+
+struct ImageData {
+    var image: UIImage?
+    var result: Result = .sucess
+    var errorDescription: String = ""
+}
+
+struct ProfileInfo {
+    var fullName: String = ""
+    var aboutYouself: String = ""
+    var profileImage: UIImage?
+}
+
+
+class GCDManager {
+    
+    func saveProfileInfo(fullName: String?, aboutYouself: String?, profileImage: UIImage?, completionHandler completion: @escaping (String)->()) {
+        var errors = ""
+        let savingGroup = DispatchGroup()
+        
+        if let fullName = fullName {
+            savingGroup.enter()
+            save(text: fullName, toFileWithName: "fullName") { result in
+                if result == .fail {
+                    errors += "Can't save full name\n"
+                }
+                savingGroup.leave()
+            }
+        }
+        if let aboutYouself = aboutYouself {
+            savingGroup.enter()
+            save(text: aboutYouself, toFileWithName: "aboutYouself") { result in
+                if result == .fail {
+                    errors += "Can't save information about you\n"
+                }
+                savingGroup.leave()
+            }
+        }
+        if let profileImage = profileImage {
+            savingGroup.enter()
+            save(image: profileImage, toFileWithName: "profileImage") { result in
+                if result == .fail {
+                    errors += "Can't save profile image\n"
+                }
+                savingGroup.leave()
+            }
+        }
+        savingGroup.notify(queue: .main) {
+            completion(errors)
+        }
+    }
+
+    func save(text str: String, toFileWithName fileName: String, completionHandler completeion: @escaping (Result) -> ()) {
+        let filePath = getDocumentDirectory().appendingPathComponent(fileName)
+        DispatchQueue.global(qos: .default).async {
+            if let data = str.data(using: .utf16) {
+                do {
+                    try data.write(to: filePath)
+                    completeion(.sucess)
+                } catch {
+                    print("Can't save file to \(filePath)")
+                    completeion(.fail)
+                }
+            } else {
+                completeion(.fail)
+            }
+        }
+    }
+    
+    func save(image img: UIImage, toFileWithName fileName: String, with completeion: @escaping (Result) -> ()) {
+        let filePath = getDocumentDirectory().appendingPathComponent(fileName)
+        DispatchQueue.global(qos: .default).async {
+            if let data = img.pngData() {
+                do {
+                    try data.write(to: filePath)
+                    completeion(.sucess)
+                    print("saved")
+                } catch {
+                    print("Can't save file to \(filePath)")
+                    completeion(.fail)
+                }
+            } else {
+                print("Can't convert image to data")
+                completeion(.fail)
+            }
+        }
+    }
+    
+    func getProfileInfo(completionHandler completion: @escaping (ProfileInfo) -> ()) {
+        var recievedFullName: String = ""
+        var recievedAboutYouself: String = ""
+        var recievedProfileImage: UIImage?
+        
+        let profileGroup = DispatchGroup()
+        
+        profileGroup.enter()
+        getString(fromFileWithName: "fullName") { result in
+            if result.result == .sucess {
+                recievedFullName = result.str
+            }
+            profileGroup.leave()
+        }
+        profileGroup.enter()
+        getString(fromFileWithName: "aboutYouself") { result in
+            if result.result == .sucess {
+                recievedAboutYouself = result.str
+            }
+            profileGroup.leave()
+        }
+        profileGroup.enter()
+        getImage(fromFileWithName: "profileImage") { result in
+            if result.result == .sucess {
+                recievedProfileImage = result.image
+            }
+            profileGroup.leave()
+        }
+
+        profileGroup.notify(queue: DispatchQueue.main) {
+            let profile = ProfileInfo(fullName: recievedFullName, aboutYouself: recievedAboutYouself, profileImage: recievedProfileImage)
+            completion(profile)
+        }
+    }
+    
+    func getString(fromFileWithName fileName: String, completionHandler completion: @escaping (StringData) -> ()) {
+        var resultData = StringData()
+        let filePath = getDocumentDirectory().appendingPathComponent(fileName)
+        DispatchQueue.global(qos: .default).async {
+            do {
+                let data = try Data(contentsOf: filePath)
+                if let savedString = String(data: data, encoding: .utf16) {
+                    resultData.str = savedString
+                    completion(resultData)
+                }
+            } catch {
+                print(error.localizedDescription)
+                resultData.result = .fail
+                resultData.errorDescription = "Can't load data from file with name \(fileName)"
+                completion(resultData)
+            }
+        }
+    }
+    
+    func getImage(fromFileWithName fileName: String, completionHandler completion: @escaping (ImageData) -> ()) {
+        var resultData = ImageData()
+        let filePath = getDocumentDirectory().appendingPathComponent(fileName)
+        DispatchQueue.global(qos: .default).async {
+            do {
+                let data = try Data(contentsOf: filePath)
+                if let savedImage = UIImage(data: data) {
+                    resultData.image = savedImage
+                    completion(resultData)
+                }
+            } catch {
+                print(error.localizedDescription)
+                resultData.result = .fail
+                resultData.errorDescription = "Can't load data from file with name \(fileName)"
+                completion(resultData)
+            }
+        }
+    }
+    
+    private func getDocumentDirectory() -> URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+    }
+}

--- a/T-Chat/GCDManager.swift
+++ b/T-Chat/GCDManager.swift
@@ -46,7 +46,7 @@ class GCDManager {
         }
     }
 
-    func save(text str: String, toFileWithName fileName: String, completionHandler completeion: @escaping (Result) -> ()) {
+    private func save(text str: String, toFileWithName fileName: String, completionHandler completeion: @escaping (Result) -> ()) {
         let filePath = getDocumentDirectory().appendingPathComponent(fileName)
         DispatchQueue.global(qos: .default).async {
             if let data = str.data(using: .utf16) {
@@ -62,7 +62,7 @@ class GCDManager {
         }
     }
     
-    func save(image img: UIImage, toFileWithName fileName: String, with completeion: @escaping (Result) -> ()) {
+    private func save(image img: UIImage, toFileWithName fileName: String, with completeion: @escaping (Result) -> ()) {
         let filePath = getDocumentDirectory().appendingPathComponent(fileName)
         DispatchQueue.global(qos: .default).async {
             if let data = img.pngData() {
@@ -113,7 +113,7 @@ class GCDManager {
         }
     }
     
-    func getString(fromFileWithName fileName: String, completionHandler completion: @escaping (StringData) -> ()) {
+    private func getString(fromFileWithName fileName: String, completionHandler completion: @escaping (StringData) -> ()) {
         var resultData = StringData()
         let filePath = getDocumentDirectory().appendingPathComponent(fileName)
         DispatchQueue.global(qos: .default).async {
@@ -132,7 +132,7 @@ class GCDManager {
         }
     }
     
-    func getImage(fromFileWithName fileName: String, completionHandler completion: @escaping (ImageData) -> ()) {
+    private func getImage(fromFileWithName fileName: String, completionHandler completion: @escaping (ImageData) -> ()) {
         var resultData = ImageData()
         let filePath = getDocumentDirectory().appendingPathComponent(fileName)
         DispatchQueue.global(qos: .default).async {

--- a/T-Chat/GCDManager.swift
+++ b/T-Chat/GCDManager.swift
@@ -8,30 +8,6 @@
 
 import UIKit
 
-enum Result {
-    case sucess
-    case fail
-}
-
-struct StringData {
-    var str: String = ""
-    var result: Result = .sucess
-    var errorDescription: String = ""
-}
-
-struct ImageData {
-    var image: UIImage?
-    var result: Result = .sucess
-    var errorDescription: String = ""
-}
-
-struct ProfileInfo {
-    var fullName: String = ""
-    var aboutYouself: String = ""
-    var profileImage: UIImage?
-}
-
-
 class GCDManager {
     
     func saveProfileInfo(fullName: String?, aboutYouself: String?, profileImage: UIImage?, completionHandler completion: @escaping (String)->()) {
@@ -76,9 +52,8 @@ class GCDManager {
             if let data = str.data(using: .utf16) {
                 do {
                     try data.write(to: filePath)
-                    completeion(.sucess)
+                    completeion(.success)
                 } catch {
-                    print("Can't save file to \(filePath)")
                     completeion(.fail)
                 }
             } else {
@@ -93,14 +68,11 @@ class GCDManager {
             if let data = img.pngData() {
                 do {
                     try data.write(to: filePath)
-                    completeion(.sucess)
-                    print("saved")
+                    completeion(.success)
                 } catch {
-                    print("Can't save file to \(filePath)")
                     completeion(.fail)
                 }
             } else {
-                print("Can't convert image to data")
                 completeion(.fail)
             }
         }
@@ -115,21 +87,21 @@ class GCDManager {
         
         profileGroup.enter()
         getString(fromFileWithName: "fullName") { result in
-            if result.result == .sucess {
+            if result.result == .success {
                 recievedFullName = result.str
             }
             profileGroup.leave()
         }
         profileGroup.enter()
         getString(fromFileWithName: "aboutYouself") { result in
-            if result.result == .sucess {
+            if result.result == .success {
                 recievedAboutYouself = result.str
             }
             profileGroup.leave()
         }
         profileGroup.enter()
         getImage(fromFileWithName: "profileImage") { result in
-            if result.result == .sucess {
+            if result.result == .success {
                 recievedProfileImage = result.image
             }
             profileGroup.leave()

--- a/T-Chat/Multithreading managers structs.swift
+++ b/T-Chat/Multithreading managers structs.swift
@@ -1,0 +1,32 @@
+//
+//  Multithreading managers structs.swift
+//  T-Chat
+//
+//  Created by Дмитрий on 20.10.2020.
+//  Copyright © 2020 DP. All rights reserved.
+//
+
+import UIKit
+
+enum Result {
+    case success
+    case fail
+}
+
+struct StringData {
+    var str: String = ""
+    var result: Result = .success
+    var errorDescription: String = ""
+}
+
+struct ImageData {
+    var image: UIImage?
+    var result: Result = .success
+    var errorDescription: String = ""
+}
+
+struct ProfileInfo {
+    var fullName: String = ""
+    var aboutYouself: String = ""
+    var profileImage: UIImage?
+}

--- a/T-Chat/OperationManager.swift
+++ b/T-Chat/OperationManager.swift
@@ -1,0 +1,82 @@
+//
+//  OperationManager.swift
+//  T-Chat
+//
+//  Created by Дмитрий on 20.10.2020.
+//  Copyright © 2020 DP. All rights reserved.
+//
+
+import UIKit
+
+class OperationManager {
+    
+    func saveProfileInfo(fullName: String?, aboutYouself: String?, profileImage: UIImage?, completionHandler completion: @escaping (String)->()) {
+        let queue = OperationQueue()
+        var errors: String = ""
+        
+        if let name = fullName {
+            queue.addOperation { [weak self] in
+                self?.save(text: name, toFileWithName: "fullName") { result in
+                    if result == .fail {
+                        errors += "Couldn't save full name\n"
+                    }
+                }
+            }
+        }
+        if let about = aboutYouself {
+            queue.addOperation { [weak self] in
+                self?.save(text: about, toFileWithName: "aboutYouself") { result in
+                    if result == .fail {
+                        errors += "Couldn't save full name\n"
+                    }
+                }
+            }
+        }
+        if let image = profileImage {
+            queue.addOperation { [weak self] in
+                self?.save(image: image, toFileWithName: "profileImage") { result in
+                    if result == .fail {
+                        errors += "Couldn't save profile image\n"
+                    }
+                }
+            }
+        }
+    
+        queue.waitUntilAllOperationsAreFinished()
+        completion(errors)
+    }
+    
+    func save(text str: String, toFileWithName fileName: String, completion: (Result)->()) {
+        let filePath = getDocumentDirectory().appendingPathComponent(fileName)
+        if let data = str.data(using: .utf16) {
+            do {
+                try data.write(to: filePath)
+                completion(.success)
+            } catch {
+                print("Can't save file to \(filePath)")
+                completion(.fail)
+            }
+        } else {
+            completion(.fail)
+        }
+    }
+    
+    func save(image: UIImage, toFileWithName fileName: String, completion: (Result)->()) {
+        let filePath = getDocumentDirectory().appendingPathComponent(fileName)
+        if let data = image.pngData() {
+            do {
+                try data.write(to: filePath)
+                completion(.success)
+            } catch {
+                completion(.fail)
+            }
+        } else {
+            completion(.fail)
+        }
+    }
+    
+    private func getDocumentDirectory() -> URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+    }
+    
+}

--- a/T-Chat/ProfileViewController.storyboard
+++ b/T-Chat/ProfileViewController.storyboard
@@ -16,29 +16,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fbM-l1-eIy">
-                                <rect key="frame" x="47" y="596" width="281" height="41"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="fbM-l1-eIy" secondAttribute="height" multiplier="137:20" id="2VM-VZ-Yen"/>
-                                    <constraint firstAttribute="height" constant="41" id="kJM-VK-ezE"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="24"/>
-                                <state key="normal" title="Save">
-                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="medium"/>
-                                </state>
-                            </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Junior iOS developer, Moscow, Russia" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4ca-ZC-OQ8">
-                                <rect key="frame" x="43" y="446" width="289" height="20.5"/>
-                                <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Dmitriy Popov" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b9m-4T-429">
-                                <rect key="frame" x="108" y="386" width="159" height="30"/>
-                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="25"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AeX-pe-N8g">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="96"/>
                                 <subviews>
@@ -49,11 +26,11 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8mj-JR-vhV">
-                                        <rect key="frame" x="316" y="31.5" width="44" height="33"/>
+                                        <rect key="frame" x="330" y="31.5" width="30" height="33"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <state key="normal" title="Close"/>
+                                        <state key="normal" title="Edit"/>
                                         <connections>
-                                            <action selector="closeButtonTapped:" destination="nQr-qR-QlQ" eventType="touchUpInside" id="9ew-YP-Hrq"/>
+                                            <action selector="editProfileButtonTapped:" destination="nQr-qR-QlQ" eventType="touchUpInside" id="xrW-hV-pNE"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -67,19 +44,19 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S6k-UJ-Ks4">
-                                <rect key="frame" x="62.5" y="106" width="250" height="250"/>
+                                <rect key="frame" x="75" y="106" width="225" height="225"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="WW" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="4eh-dB-pfr">
-                                        <rect key="frame" x="12.5" y="12.5" width="225" height="225"/>
+                                        <rect key="frame" x="11.5" y="11.5" width="202.5" height="202.5"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="110"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="vQy-o1-zAd">
-                                        <rect key="frame" x="0.0" y="0.0" width="250" height="250"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="225" height="225"/>
                                     </imageView>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CzP-ww-iOf">
-                                        <rect key="frame" x="215" y="220" width="35" height="30"/>
+                                    <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CzP-ww-iOf">
+                                        <rect key="frame" x="190" y="198" width="35" height="27"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="35" id="qHt-Qi-r3f"/>
                                         </constraints>
@@ -104,37 +81,76 @@
                                     <constraint firstAttribute="width" secondItem="S6k-UJ-Ks4" secondAttribute="height" multiplier="1:1" id="zkG-nQ-JTA"/>
                                 </constraints>
                             </view>
+                            <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Dmitrii Popov" textAlignment="center" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="J2R-v7-fIq">
+                                <rect key="frame" x="30" y="351" width="315" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                <textInputTraits key="textInputTraits" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
+                            </textField>
+                            <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mgO-1c-VPc">
+                                <rect key="frame" x="205.5" y="596" width="139.5" height="41"/>
+                                <color key="backgroundColor" red="1" green="0.75633496050000004" blue="0.38538342710000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="mgO-1c-VPc" secondAttribute="height" multiplier="68:20" id="3VC-Hf-ZKQ"/>
+                                    <constraint firstAttribute="height" constant="41" id="ySz-aA-ozL"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="24"/>
+                                <state key="normal" title="Operational">
+                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="medium"/>
+                                </state>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fbM-l1-eIy">
+                                <rect key="frame" x="30" y="596" width="139.5" height="41"/>
+                                <color key="backgroundColor" red="0.99953407049999998" green="0.98835557699999999" blue="0.47265523669999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="fbM-l1-eIy" secondAttribute="height" multiplier="68:20" id="2VM-VZ-Yen"/>
+                                    <constraint firstAttribute="height" constant="41" id="kJM-VK-ezE"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="24"/>
+                                <state key="normal" title="GCD">
+                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="medium"/>
+                                </state>
+                            </button>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="Junior iOS developer, Moscow" textAlignment="center" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g1Z-r2-s9E">
+                                <rect key="frame" x="30" y="392" width="315" height="184"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
+                            </textView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="AeX-pe-N8g" firstAttribute="top" secondItem="O0m-Kt-HHG" secondAttribute="top" id="0r6-m4-b2i"/>
                             <constraint firstAttribute="bottom" secondItem="fbM-l1-eIy" secondAttribute="bottom" constant="30" id="2mq-ez-n8L"/>
-                            <constraint firstItem="b9m-4T-429" firstAttribute="top" secondItem="S6k-UJ-Ks4" secondAttribute="bottom" constant="30" id="Avo-st-zVG"/>
-                            <constraint firstItem="fbM-l1-eIy" firstAttribute="top" relation="greaterThanOrEqual" secondItem="4ca-ZC-OQ8" secondAttribute="bottom" constant="30" id="Bb9-Mp-BIU"/>
-                            <constraint firstItem="O0m-Kt-HHG" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="4ca-ZC-OQ8" secondAttribute="trailing" constant="30" id="KyB-fy-Eer"/>
-                            <constraint firstItem="4ca-ZC-OQ8" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="O0m-Kt-HHG" secondAttribute="leading" constant="30" id="LHN-w2-nL0"/>
-                            <constraint firstItem="S6k-UJ-Ks4" firstAttribute="width" secondItem="bM5-U5-LjI" secondAttribute="width" multiplier="2:3" id="PJ0-Nd-Hoi"/>
-                            <constraint firstItem="fbM-l1-eIy" firstAttribute="centerX" secondItem="bM5-U5-LjI" secondAttribute="centerX" id="RG2-jC-i08"/>
-                            <constraint firstItem="4ca-ZC-OQ8" firstAttribute="top" secondItem="b9m-4T-429" secondAttribute="bottom" constant="30" id="T30-l8-GKM"/>
+                            <constraint firstItem="fbM-l1-eIy" firstAttribute="leading" secondItem="O0m-Kt-HHG" secondAttribute="leading" constant="30" id="CUn-bx-XZH"/>
+                            <constraint firstItem="mgO-1c-VPc" firstAttribute="centerY" secondItem="fbM-l1-eIy" secondAttribute="centerY" id="Cjs-iQ-y9S"/>
+                            <constraint firstItem="O0m-Kt-HHG" firstAttribute="trailing" secondItem="J2R-v7-fIq" secondAttribute="trailing" constant="30" id="JAW-Py-DgS"/>
+                            <constraint firstItem="J2R-v7-fIq" firstAttribute="top" secondItem="S6k-UJ-Ks4" secondAttribute="bottom" constant="20" id="JSg-ny-8i0"/>
+                            <constraint firstItem="g1Z-r2-s9E" firstAttribute="width" secondItem="J2R-v7-fIq" secondAttribute="width" id="LNH-xQ-v4T"/>
+                            <constraint firstItem="fbM-l1-eIy" firstAttribute="top" secondItem="g1Z-r2-s9E" secondAttribute="bottom" constant="20" id="N1L-dz-5Ug"/>
+                            <constraint firstItem="S6k-UJ-Ks4" firstAttribute="width" secondItem="bM5-U5-LjI" secondAttribute="width" multiplier="3:5" id="PJ0-Nd-Hoi"/>
+                            <constraint firstItem="O0m-Kt-HHG" firstAttribute="trailing" secondItem="mgO-1c-VPc" secondAttribute="trailing" constant="30" id="WiP-5j-59B"/>
                             <constraint firstItem="S6k-UJ-Ks4" firstAttribute="top" secondItem="AeX-pe-N8g" secondAttribute="bottom" constant="10" id="XN6-7A-yjF"/>
-                            <constraint firstItem="b9m-4T-429" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="O0m-Kt-HHG" secondAttribute="leading" constant="30" id="aXQ-Po-qsc"/>
-                            <constraint firstItem="4ca-ZC-OQ8" firstAttribute="centerX" secondItem="b9m-4T-429" secondAttribute="centerX" id="bhs-tq-o7L"/>
+                            <constraint firstItem="mgO-1c-VPc" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="fbM-l1-eIy" secondAttribute="trailing" constant="15" id="ZY9-yn-V6f"/>
+                            <constraint firstItem="g1Z-r2-s9E" firstAttribute="top" secondItem="J2R-v7-fIq" secondAttribute="bottom" constant="20" id="bd4-ze-MVa"/>
                             <constraint firstItem="AeX-pe-N8g" firstAttribute="leading" secondItem="O0m-Kt-HHG" secondAttribute="leading" id="bvL-xc-rOB"/>
-                            <constraint firstItem="O0m-Kt-HHG" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="b9m-4T-429" secondAttribute="trailing" constant="30" id="flF-Ug-z0P"/>
-                            <constraint firstItem="b9m-4T-429" firstAttribute="centerX" secondItem="bM5-U5-LjI" secondAttribute="centerX" id="gr8-BZ-Uqe"/>
+                            <constraint firstItem="g1Z-r2-s9E" firstAttribute="centerX" secondItem="J2R-v7-fIq" secondAttribute="centerX" id="fuu-UL-asg"/>
+                            <constraint firstItem="mgO-1c-VPc" firstAttribute="width" secondItem="mgO-1c-VPc" secondAttribute="height" multiplier="68:20" id="ibH-ID-cZv"/>
+                            <constraint firstItem="J2R-v7-fIq" firstAttribute="leading" secondItem="O0m-Kt-HHG" secondAttribute="leading" constant="30" id="sff-9y-nkN"/>
                             <constraint firstItem="AeX-pe-N8g" firstAttribute="trailing" secondItem="O0m-Kt-HHG" secondAttribute="trailing" id="x3R-0R-FYh"/>
                             <constraint firstItem="S6k-UJ-Ks4" firstAttribute="centerX" secondItem="bM5-U5-LjI" secondAttribute="centerX" id="xoH-hE-wyQ"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="O0m-Kt-HHG"/>
                     </view>
                     <connections>
-                        <outlet property="editButton" destination="CzP-ww-iOf" id="fNe-uK-LQy"/>
-                        <outlet property="nameAndSurnameLabel" destination="b9m-4T-429" id="7IJ-lY-OWH"/>
+                        <outlet property="aboutYouselfTextView" destination="g1Z-r2-s9E" id="kHO-iG-Zgb"/>
+                        <outlet property="avatarEditButton" destination="CzP-ww-iOf" id="fNe-uK-LQy"/>
+                        <outlet property="gcdSaveButton" destination="fbM-l1-eIy" id="uCy-8u-Rcz"/>
+                        <outlet property="nameAndSurnameTextField" destination="J2R-v7-fIq" id="V34-tf-pT8"/>
                         <outlet property="nameLabel" destination="4eh-dB-pfr" id="PTf-9G-FNS"/>
                         <outlet property="nameLabelContainerView" destination="S6k-UJ-Ks4" id="TTZ-RO-UAZ"/>
+                        <outlet property="operationalSaveButton" destination="mgO-1c-VPc" id="uKC-2W-JOg"/>
                         <outlet property="profileImageView" destination="vQy-o1-zAd" id="J2q-LV-zWY"/>
-                        <outlet property="saveButton" destination="fbM-l1-eIy" id="FvN-DS-9S7"/>
-                        <outlet property="youselfDescriptionLabel" destination="4ca-ZC-OQ8" id="xPj-tV-VZ5"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="rpm-IC-IPF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/T-Chat/ProfileViewController.storyboard
+++ b/T-Chat/ProfileViewController.storyboard
@@ -94,7 +94,7 @@
                                     <constraint firstAttribute="height" constant="41" id="ySz-aA-ozL"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="24"/>
-                                <state key="normal" title="Operational">
+                                <state key="normal" title="Operation">
                                     <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="medium"/>
                                 </state>
                             </button>

--- a/T-Chat/ProfileViewController.storyboard
+++ b/T-Chat/ProfileViewController.storyboard
@@ -110,7 +110,7 @@
                                     <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="medium"/>
                                 </state>
                             </button>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="Junior iOS developer, Moscow" textAlignment="center" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g1Z-r2-s9E">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="Junior iOS developer" textAlignment="center" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g1Z-r2-s9E">
                                 <rect key="frame" x="30" y="392" width="315" height="184"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
@@ -145,6 +145,7 @@
                     <connections>
                         <outlet property="aboutYouselfTextView" destination="g1Z-r2-s9E" id="kHO-iG-Zgb"/>
                         <outlet property="avatarEditButton" destination="CzP-ww-iOf" id="fNe-uK-LQy"/>
+                        <outlet property="editButton" destination="8mj-JR-vhV" id="0oP-eL-Jkx"/>
                         <outlet property="gcdSaveButton" destination="fbM-l1-eIy" id="uCy-8u-Rcz"/>
                         <outlet property="nameAndSurnameTextField" destination="J2R-v7-fIq" id="V34-tf-pT8"/>
                         <outlet property="nameLabel" destination="4eh-dB-pfr" id="PTf-9G-FNS"/>

--- a/T-Chat/ProfileViewController.swift
+++ b/T-Chat/ProfileViewController.swift
@@ -12,7 +12,8 @@ import AVFoundation
 class ProfileViewController: UIViewController {
     
     lazy var activityIndicator = UIActivityIndicatorView()
-    lazy var manager = GCDManager()
+//    lazy var manager = GCDManager()
+    lazy var manager = OperationManager()
     
     var currentFullName: String = ""
     var currentAboutYouself: String = ""

--- a/T-Chat/ProfileViewController.swift
+++ b/T-Chat/ProfileViewController.swift
@@ -10,7 +10,12 @@ import UIKit
 import AVFoundation
 
 class ProfileViewController: UIViewController {
+    
+    lazy var activityIndicator = UIActivityIndicatorView()
+    var currentFullName: String = ""
+    var currentAboutYouself: String = ""
 
+    @IBOutlet weak var editButton: UIButton!
     @IBOutlet weak var gcdSaveButton: UIButton!
     @IBOutlet weak var operationalSaveButton: UIButton!
     @IBOutlet weak var nameLabel: UILabel!
@@ -22,16 +27,30 @@ class ProfileViewController: UIViewController {
 
     @IBAction func editProfileButtonTapped(_ sender: UIButton) {
         if sender.titleLabel?.text == "Edit" {
+            currentFullName = nameAndSurnameTextField.text ?? ""
+            currentAboutYouself = aboutYouselfTextView.text
             sender.setTitle("Cancel", for: .normal)
             editProfileOn()
         } else {
             sender.setTitle("Edit", for: .normal)
             editProfileOff()
+            nameAndSurnameTextField.text = currentFullName
+            aboutYouselfTextView.text = currentAboutYouself
         }
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        getProfileInfo()
+        
+        activityIndicator.hidesWhenStopped = true
+        view.addSubview(activityIndicator)
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
         
         nameAndSurnameTextField.delegate = self
         aboutYouselfTextView.delegate = self
@@ -40,7 +59,7 @@ class ProfileViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(notification:)), name: UIResponder.keyboardWillHideNotification, object: nil)
 
         profileImageView.isHidden = true
-        avatarEditButton.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
+        avatarEditButton.addTarget(self, action: #selector(avatarEditButtonTapped), for: .touchUpInside)
         nameLabel.text = getNameLabelLetters()
         aboutYouselfTextView.layer.cornerRadius = 5
         nameAndSurnameTextField.layer.cornerRadius = 5
@@ -57,7 +76,7 @@ class ProfileViewController: UIViewController {
         operationalSaveButton.layer.cornerRadius = gcdSaveButton.bounds.height / 4
     }
     
-    @objc func editButtonTapped() {
+    @objc func avatarEditButtonTapped() {
         let ac = UIAlertController(title: "Edit profile photo", message: nil, preferredStyle: .actionSheet)
         
         // action для выбора фотографии из галереи
@@ -89,6 +108,7 @@ class ProfileViewController: UIViewController {
         }
         return finalStr.uppercased()
     }
+    
 //    Метод для инициализации viewController с помощью имени сториборда. Имена контроллера и сториборда одинаковые для того, чтобы не использовать storyboardID для инициализации.
     static func storyboardInstance() -> ProfileViewController? {
         let storyboard = UIStoryboard(name: String(describing: self), bundle: nil)
@@ -96,12 +116,20 @@ class ProfileViewController: UIViewController {
     }
     
     @objc func gcdButtonTapped() {
-        navigationItem.rightBarButtonItem?.title = "Edit"
         editProfileOff()
+        guard let fullName = nameAndSurnameTextField.text else { return }
+        if fullName != currentFullName {
+            saveStringData(nameAndSurnameTextField.text ?? "", withFileName: "fullName")
+        }
+        if aboutYouselfTextView.text != currentAboutYouself {
+            saveStringData(aboutYouselfTextView.text, withFileName: "aboutYouSelf")
+        }
+        if let profilePhoto = profileImageView.image {
+            saveImageData(profilePhoto)
+        }
     }
     
     @objc func operationalButtonTapped() {
-        navigationItem.rightBarButtonItem?.title = "Edit"
         editProfileOff()
     }
     
@@ -112,6 +140,112 @@ class ProfileViewController: UIViewController {
     
     @objc func keyboardWillHide(notification: NSNotification) {
       self.view.frame.origin.y = 0
+    }
+    
+    func getProfileInfo() {
+        let documentsDirectory = getDocumentsDirectory()
+        let fullNamePath = documentsDirectory.appendingPathComponent("fullName").appendingPathExtension("txt")
+        let aboutYouselfPath = documentsDirectory.appendingPathComponent("aboutYouSelf").appendingPathExtension("txt")
+        let profilePhotoPath = documentsDirectory.appendingPathComponent("profilePhoto").appendingPathExtension("png")
+        activityIndicator.startAnimating()
+        DispatchQueue.global(qos: .userInteractive).async { [weak self] in
+            do {
+                let fullNameData = try Data(contentsOf: fullNamePath)
+                if let fullName = String(data: fullNameData, encoding: .utf16) {
+                    DispatchQueue.main.async { [weak self] in
+                        self?.nameAndSurnameTextField.text = fullName
+                        self?.nameLabel.text = self?.getNameLabelLetters()
+                    }
+                }
+                let aboutYouselfData = try Data(contentsOf: aboutYouselfPath)
+                if let aboutYouself = String(data: aboutYouselfData, encoding: .utf16) {
+                    DispatchQueue.main.async { [weak self] in
+                        self?.aboutYouselfTextView.text = aboutYouself
+                    }
+                }
+                let profileImageData = try Data(contentsOf: profilePhotoPath)
+                if let profilePhoto = UIImage(data: profileImageData) {
+                    DispatchQueue.main.async { [weak self] in
+                        self?.profileImageView.image = profilePhoto
+                        self?.profileImageView.isHidden = false
+                        self?.nameLabel.isHidden = true  
+                    }
+                }
+                DispatchQueue.main.async { [weak self] in
+                    self?.activityIndicator.stopAnimating()
+                }
+            } catch {
+                print("can't read data")
+                DispatchQueue.main.async { [weak self] in
+                    self?.activityIndicator.stopAnimating()
+                }
+            }
+        }
+    }
+    
+    func saveStringData(_ text: String, withFileName name: String) {
+        activityIndicator.startAnimating()
+        let ac = getDefaultAlertController(withTitle: "Data was saved", andMessage: nil)
+        let queue = DispatchQueue.global(qos: .default)
+        let path = getDocumentsDirectory().appendingPathComponent(name).appendingPathExtension("txt")
+        if let data = text.data(using: .utf16) {
+            queue.async {
+                do {
+                    try data.write(to: path)
+                    DispatchQueue.main.async { [weak self] in
+                        self?.activityIndicator.stopAnimating()
+                        self?.present(ac, animated: true)
+                    }
+                                    } catch {
+                    DispatchQueue.main.async { [weak self] in
+                        self?.activityIndicator.stopAnimating()
+                        ac.title = "Error"
+                        ac.message = "Couldn't save data"
+                        ac.addAction(UIAlertAction(title: "Repeat", style: .default, handler: { [weak self] _ in
+                            self?.saveStringData(text, withFileName: name)
+                        }))
+                    }
+                }
+            }
+        }
+    }
+    
+    func saveImageData(_ image: UIImage) {
+        activityIndicator.startAnimating()
+        let ac = getDefaultAlertController(withTitle: "Data was saved", andMessage: nil)
+        let queue = DispatchQueue.global(qos: .default)
+        let path = getDocumentsDirectory().appendingPathComponent("profilePhoto").appendingPathExtension("png")
+        if let data = image.pngData() {
+            queue.async {
+                do {
+                    try data.write(to: path)
+                    DispatchQueue.main.async { [weak self] in
+                        self?.activityIndicator.stopAnimating()
+                        self?.present(ac, animated: true)
+                    }
+                } catch {
+                    DispatchQueue.main.async { [weak self] in
+                        self?.activityIndicator.stopAnimating()
+                        ac.title = "Error"
+                        ac.message = "Couldn't save data"
+                        ac.addAction(UIAlertAction(title: "Repeat", style: .default, handler: { [weak self] _ in
+                            self?.saveImageData(image)
+                        }))
+                    }
+                }
+            }
+        }
+    }
+    
+    func getDefaultAlertController(withTitle title: String, andMessage message: String?) -> UIAlertController {
+        let ac = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        ac.addAction(UIAlertAction(title: "Ok", style: .default))
+        return ac
+    }
+    
+    func getDocumentsDirectory() -> URL {
+        let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+        return paths[0]
     }
     
     private func editProfileOn() {
@@ -128,6 +262,7 @@ class ProfileViewController: UIViewController {
         aboutYouselfTextView.isEditable = false
         aboutYouselfTextView.backgroundColor = .white
         buttons(disable: [gcdSaveButton, operationalSaveButton, avatarEditButton])
+        editButton.setTitle("Edit", for: .normal)
         resignFirstResponder()
     }
     

--- a/T-Chat/exampleView.storyboard
+++ b/T-Chat/exampleView.storyboard
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qOE-h6-ogQ">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Example View-->
+        <scene sceneID="4Mt-2L-3e0">
+            <objects>
+                <viewController id="qOE-h6-ogQ" customClass="exampleView" customModule="T_Chat" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="rUB-ZW-DTY">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="jyP-GE-cML">
+                                <rect key="frame" x="20" y="431" width="374" height="34"/>
+                                <color key="backgroundColor" red="0.99953407049999998" green="0.98835557699999999" blue="0.47265523669999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" enablesReturnKeyAutomatically="YES"/>
+                            </textField>
+                            <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="OVe-zX-oiU">
+                                <rect key="frame" x="20" y="495" width="374" height="34"/>
+                                <color key="backgroundColor" red="1" green="0.75633496050000004" blue="0.38538342710000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" enablesReturnKeyAutomatically="YES"/>
+                            </textField>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Xhm-bQ-nEe">
+                                <rect key="frame" x="132" y="359" width="150" height="42"/>
+                                <color key="backgroundColor" red="0.0" green="0.46189910169999998" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="150" id="Mw6-ge-zFI"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
+                                <state key="normal">
+                                    <color key="titleColor" red="1" green="1" blue="0.99607843139999996" alpha="1" colorSpace="calibratedRGB"/>
+                                </state>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="jyP-GE-cML" firstAttribute="centerY" secondItem="rUB-ZW-DTY" secondAttribute="centerY" id="1IN-Eu-dvq"/>
+                            <constraint firstItem="OVe-zX-oiU" firstAttribute="top" secondItem="jyP-GE-cML" secondAttribute="bottom" constant="30" id="Ar6-Yw-wAJ"/>
+                            <constraint firstItem="Xhm-bQ-nEe" firstAttribute="centerX" secondItem="OVe-zX-oiU" secondAttribute="centerX" id="DHT-vv-wA6"/>
+                            <constraint firstItem="jyP-GE-cML" firstAttribute="top" secondItem="Xhm-bQ-nEe" secondAttribute="bottom" constant="30" id="EEV-qh-5kq"/>
+                            <constraint firstItem="OVe-zX-oiU" firstAttribute="width" secondItem="jyP-GE-cML" secondAttribute="width" id="P4K-A9-T0p"/>
+                            <constraint firstItem="OVe-zX-oiU" firstAttribute="centerX" secondItem="jyP-GE-cML" secondAttribute="centerX" id="PDG-jH-W0z"/>
+                            <constraint firstItem="3fl-Pe-RYY" firstAttribute="trailing" secondItem="jyP-GE-cML" secondAttribute="trailing" constant="20" id="ZeW-P9-v4b"/>
+                            <constraint firstItem="jyP-GE-cML" firstAttribute="leading" secondItem="3fl-Pe-RYY" secondAttribute="leading" constant="20" id="aPn-GF-Zdw"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="3fl-Pe-RYY"/>
+                    </view>
+                    <connections>
+                        <outlet property="editSaveButton" destination="Xhm-bQ-nEe" id="LOG-Am-X2n"/>
+                        <outlet property="textFieldOne" destination="jyP-GE-cML" id="74O-X1-xOl"/>
+                        <outlet property="textFieldTwo" destination="OVe-zX-oiU" id="lja-yB-1xB"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="fM9-MO-bGm" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="141" y="149"/>
+        </scene>
+    </scenes>
+</document>

--- a/T-Chat/exampleView.swift
+++ b/T-Chat/exampleView.swift
@@ -1,0 +1,82 @@
+//
+//  exampleView.swift
+//  T-Chat
+//
+//  Created by Дмитрий on 12.10.2020.
+//  Copyright © 2020 DP. All rights reserved.
+//
+
+import UIKit
+
+class exampleView: UIViewController, UITextFieldDelegate {
+    @IBOutlet weak var textFieldOne: UITextField!
+    @IBOutlet weak var textFieldTwo: UITextField!
+    @IBOutlet weak var editSaveButton: UIButton!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        textFieldOne.text = "This is textfield one"
+        textFieldTwo.text = "This is textfield two"
+        
+        textFieldOne.delegate = self
+        textFieldTwo.delegate = self
+        
+        editSaveButton.setTitle("Edit", for: .normal)
+        editSaveButton.addTarget(self, action: #selector(editOrSaveAction(_:)), for: .touchUpInside)
+
+        // Do any additional setup after loading the view.
+    }
+    
+    @objc private func editOrSaveAction(_ sender: UIButton) {
+        guard let title = sender.titleLabel?.text else { return }
+        
+        if title == "Edit" {
+            sender.setTitle("Save", for: .normal)
+            textFieldOne.isUserInteractionEnabled = true
+            textFieldTwo.isUserInteractionEnabled = true
+            textFieldOne.becomeFirstResponder()
+        } else {
+            sender.setTitle("Edit", for: .normal)
+            textFieldOne.isUserInteractionEnabled = false
+            textFieldTwo.isUserInteractionEnabled = false
+            resignFirstResponder()
+            saveDataToFile()
+        }
+    }
+    
+    func saveDataToFile() {
+        guard let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
+        let tfoURL = URL(fileURLWithPath: "FirstTF", relativeTo: documentDirectory)
+        
+        let savedText = textFieldOne.text ?? ""
+        let ac = UIAlertController(title: "Saving result", message: nil, preferredStyle: .alert)
+        ac.addAction(UIAlertAction(title: "Ok", style: .default))
+        if let data = savedText.data(using: .utf8) {
+            do {
+                try data.write(to: tfoURL)
+                ac.message = "File saved succesfuly"
+                
+            } catch {
+                ac.message = "Something goes wrong! Can't save data"
+            }
+        }
+        present(ac, animated: true)
+        
+        
+    }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        switch textField {
+        case textFieldOne:
+            textFieldTwo.becomeFirstResponder()
+        default:
+            textField.resignFirstResponder()
+        }
+        return false
+    }
+    
+
+    
+
+}


### PR DESCRIPTION
Много времени понадобилось, чтобы уверенно разобраться с замыканиями, но я закончил этот блок.
Будет классно, если дадите обратную связь по работе, в частности у меня остались сомнения о правильности перехода в mainThread через Operations.

Ниже основные комментарии по домашней работе:
- Кнопки GCD и Operation активны сразу при входе в режим редактирования профиля, но если данные не были изменены то метод сохранения не срабатывает, а на экране отображается alert с указанием о том, что данные не были изменены.
- При нажатии любой из кнопок сохранения возможность повторного нажатия исключается вызовом метода editProfileOff(), который делает невозможным изменение данных (текстовых и аватара), а также деактивирует кнопки сохранения.
- При неуспешном сохранении данных в сообщении будет отражено, что именно не сохранилось. Но есть недоработка, при нажатии кнопки повторить будет попытка сохранить те же данные, что и при основном вызове, даже если что-то из этого сохранилось в прошлый раз.
- При входе в режим редактирования подтягиваются данные из аутлетов, для того, чтобы с ними потом сравнивать изменения. Кнопка Edit в правом углу меняется на Cancel. Если изменить данные и нажать Cancel, то на экран вернутся данные сохранённые до входа в режим редактирования.
- Для получения данных через Operations или GCD нужно раскомментировать строчку с инициализацией соответствующего менеджера в самом начале ProfileViewController.